### PR TITLE
Change exec path to /usr/bin/wkhtmltopdf

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,7 @@ def application(request):
             options = json.loads(request.form.get('options', '{}'))
 
         # Evaluate argument to run with subprocess
-        args = ['/usr/local/bin/wkhtmltopdf.sh']
+        args = ['/usr/bin/wkhtmltopdf']
 
         # Add Global Options
         if options:


### PR DESCRIPTION
This fixes the "no such file" error when a request is being processed:

<pre>bash: /usr/local/bin/wkhtmltopdf.sh: No such file or directory
2014-09-02 06:30:14 [13] [ERROR] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 93, in handle
    self.handle_request(listener, req, client, addr)
  File "/usr/local/lib/python2.7/dist-packages/gunicorn/workers/sync.py", line 134, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/wrappers.py", line 286, in application
    return f(*args[:-2] + (request,))(*args[-2:])
  File "/app.py", line 57, in application
    execute(' '.join(args))
  File "/usr/local/lib/python2.7/dist-packages/executor/__init__.py", line 92, in execute
    raise ExternalCommandFailed(msg % (shell.returncode, command))
ExternalCommandFailed: External command failed with exit code 127! (command: /usr/local/bin/wkhtmltopdf.sh /tmp/tmpnTO3Fm.html /tmp/tmpnTO3Fm.html.pdf)</pre>
