### PR TITLE
Run apt-get update before installing python-pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openlabs/docker-wkhtmltopdf:latest
 MAINTAINER Sharoon Thomas <sharoon.thomas@openlabs.co.in>
 
 # Install dependencies for running web service
-RUN apt-get install -y python-pip
+RUN apt-get update && apt-get install -y python-pip
 RUN pip install werkzeug executor gunicorn
 
 ADD app.py /app.py


### PR DESCRIPTION
Was trying to run a docker container - it failed at python-pip installation with 404 error. So I added apt-get update to it
