### PR TITLE
bugfix: add apt-get update in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openlabs/docker-wkhtmltopdf:latest
 MAINTAINER Sharoon Thomas <sharoon.thomas@openlabs.co.in>
 
 # Install dependencies for running web service
-RUN apt-get install -y python-pip
+RUN apt-get update && apt-get install -y python-pip
 RUN pip install werkzeug executor gunicorn
 
 ADD app.py /app.py


### PR DESCRIPTION
Fix this bug (when building the image) : 

```
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
ERROR: Service 'html2pdf' failed to build: The command '/bin/sh -c apt-get install -y python-pip' returned a non-zero code: 100
```
