### PR TITLE
Fix doc block in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ def application(request):
     """
     To use this application, the user must send a POST request with
     base64 or form encoded encoded HTML content and the wkhtmltopdf Options in
-    request data, with keys 'base64_html' and 'options'.
+    request data, with keys 'content' and 'options'.
     The application will return a response with the PDF file.
     """
     if request.method != 'POST':


### PR DESCRIPTION
The comment in app.py explaining how to make requests to the service references an invalid key `base64_html`, which was apparently renamed `content`.