### PR TITLE
WKHTMLTOPDF_OPTS and WKHTMLTOPDF_WORKDIR env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Sharoon Thomas <sharoon.thomas@openlabs.co.in>
 # Install dependencies for running web service
 RUN apt-get update \
 	&& apt-get install -y python-pip \
-	&& pip install werkzeug executor gunicorn ushlex \
+	&& pip install werkzeug executor gunicorn \
 	&& rm -rf /var/lib/apt/lists/*
 
 ADD app.py /app.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM openlabs/docker-wkhtmltopdf:latest
 MAINTAINER Sharoon Thomas <sharoon.thomas@openlabs.co.in>
 
 # Install dependencies for running web service
-RUN apt-get install -y python-pip
-RUN pip install werkzeug executor gunicorn
+RUN apt-get update \
+	&& apt-get install -y python-pip \
+	&& pip install werkzeug executor gunicorn ushlex \
+	&& rm -rf /var/lib/apt/lists/*
 
 ADD app.py /app.py
 EXPOSE 80

--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@
 """
 import json
 import tempfile
+import ushlex as shlex
+import os
 
 from werkzeug.wsgi import wrap_file
 from werkzeug.wrappers import Request, Response
@@ -26,7 +28,8 @@ def application(request):
 
     request_is_json = request.content_type.endswith('json')
 
-    with tempfile.NamedTemporaryFile(suffix='.html') as source_file:
+    workdir=os.environ.get('WKHTMLTOPDF_WORKDIR')
+    with tempfile.NamedTemporaryFile(suffix='.html', dir=workdir, delete=True) as source_file:
 
         if request_is_json:
             # If a JSON payload is there, all data is in the payload
@@ -44,6 +47,9 @@ def application(request):
         # Evaluate argument to run with subprocess
         args = ['wkhtmltopdf']
 
+        # Add ENV options
+        args += shlex.split(os.environ.get('WKHTMLTOPDF_OPTS'))
+
         # Add Global Options
         if options:
             for option, value in options.items():
@@ -55,13 +61,18 @@ def application(request):
         file_name = source_file.name
         args += [file_name, file_name + ".pdf"]
 
-        # Execute the command using executor
-        execute(' '.join(args))
+        try:
+            # Execute the command using executor
+            execute(' '.join(args))
 
-        return Response(
-            wrap_file(request.environ, open(file_name + '.pdf')),
-            mimetype='application/pdf',
-        )
+            pdf = open(file_name + '.pdf')
+            return Response(
+                wrap_file(request.environ, pdf),
+                mimetype='application/pdf',
+            )
+        finally:
+            os.remove(file_name + '.pdf')
+
 
 
 if __name__ == '__main__':

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@
 """
 import json
 import tempfile
-import ushlex as shlex
 import os
 
 from werkzeug.wsgi import wrap_file
@@ -45,11 +44,10 @@ def application(request):
         source_file.flush()
 
         # Evaluate argument to run with subprocess
-        args = ['wkhtmltopdf']
-
-        # Add ENV options
-        args += shlex.split(os.environ.get('WKHTMLTOPDF_OPTS'))
-
+        args = []
+        
+        env_options = os.environ.get('WKHTMLTOPDF_OPTS') or ''
+        
         # Add Global Options
         if options:
             for option, value in options.items():
@@ -63,7 +61,7 @@ def application(request):
 
         try:
             # Execute the command using executor
-            execute(' '.join(args))
+            execute('wkhtmltopdf ' + env_options + ' ' + ' '.join(args))
 
             pdf = open(file_name + '.pdf')
             return Response(


### PR DESCRIPTION
WKHTMLTOPDF_OPTS env variable allow to add custom options to be applied for all requests,
WKHTMLTOPDF_WORKDIR allow to specify the directory for the html file (/tmp by default). This is usefull if the file references some external files by relative path (eg. fonts) that need to be in the same folder.

other minors:
- single RUN -> only one layer instead of 2
- remove tmp file

docker-compose.yml:
```
wkhtmltopdf-aas:
    image: openlabs/docker-wkhtmltopdf-aas
    build:
      context: .
    volumes:
     - ./static:/static
    environment:
     - WKHTMLTOPDF_OPTS=--disable-local-file-access --allow /static
     - WKHTMLTOPDF_WORKDIR=/static
```